### PR TITLE
fix: object ownership

### DIFF
--- a/terraform/s3.tf
+++ b/terraform/s3.tf
@@ -45,11 +45,21 @@ resource "aws_s3_bucket_policy" "s3-bucket-cur-report-policy" {
         "AWS": "arn:aws:iam::${var.stacklet_saas_account_id}:role/${var.customer_prefix}-cur-read"
       },
       "Action": [
-        "s3:ListBucket",
+        "s3:ListBucket"
+      ],
+      "Resource": [
+        "arn:aws:s3:::${local.s3_bucket_name}"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::${var.stacklet_saas_account_id}:role/${var.customer_prefix}-cur-read"
+      },
+      "Action": [
         "s3:GetObject"
       ],
       "Resource": [
-        "arn:aws:s3:::${local.s3_bucket_name}",
         "arn:aws:s3:::${local.s3_bucket_name}/*"
       ]
     }


### PR DESCRIPTION
By default when a CUR is setup it uses a service account to write objects to the s3 bucket.   If we don't force ownership all objects written will be owned by the service account and now the owner of the bucket and so they will not be able to read the objects.

This surfaces itself this way in glue:
```
[df6758c8-2ce2-4394-b31f-73b35669fde7] ERROR : Not all read errors will be logged. com.amazonaws.services.s3.model.AmazonS3Exception: Access Denied (Service: Amazon S3; Status Code: 403; Error Code: AccessDenied; Request ID: RBKH9RRVZAGDASHC; S3 Extended Request ID: dEZzHar8sZAf07cjN41kXJocvPVo7hTuCtqlY7OFNGCzQ5oSwWsgcHxoUJXBONjozJrPfcQ/ymdjY30Ew0ZKYg==; Proxy: null), S3 Extended Request ID: dEZzHar8sZAf07cjN41kXJocvPVo7hTuCtqlY7OFNGCzQ5oSwWsgcHxoUJXBONjozJrPfcQ/ymdjY30Ew0ZKYg==
--


<br class="Apple-interchange-newline">
```

and this way in the CLI:
```
fatal error: An error occurred (403) when calling the HeadObject operation: Forbidden
```