### PR TITLE
chore: Lock down Azure storage account (ENG-5446)

### DIFF
--- a/terraform/cost_management.tf
+++ b/terraform/cost_management.tf
@@ -16,6 +16,9 @@ resource "azurerm_storage_account" "cost" {
   location                 = azurerm_resource_group.current[0].location
   account_tier             = "Standard"
   account_replication_type = "LRS"
+
+  allow_nested_items_to_be_public = false
+  shared_access_key_enabled       = false
 }
 
 resource "azurerm_storage_container" "cost" {


### PR DESCRIPTION
[ENG-5446](https://stacklet.atlassian.net/browse/ENG-5446)

### what

assetdb's azure-cost-sync already authenticates with a service principal, so we don't need a shared access key.

And there's no need to allow anything in the account to be public, even though nothing should be trying to create public things.

### why

These features are unnecessary attack surface.

### testing

Manually verified the behaviour on Canary.

### docs

https://github.com/stacklet/docs/pull/484

[ENG-5446]: https://stacklet.atlassian.net/browse/ENG-5446?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ